### PR TITLE
singleton: Allocate singleton instance on heap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,12 +57,30 @@ matrix:
             - ubuntu-toolchain-r-test
 
     - os: linux
+      compiler: g++-7
+      env: TOOLSET=gcc-7 LINK=static
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      compiler: clang++
+      env: TOOLSET=clang
+
+    - os: linux
+      compiler: clang++
+      env: TOOLSET=clang LINK=static
+
+    - os: osx
       compiler: clang++
       env: TOOLSET=clang
 
     - os: osx
       compiler: clang++
-      env: TOOLSET=clang
+      env: TOOLSET=clang LINK=static
 
 install:
   - BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
@@ -78,7 +96,7 @@ install:
   - ./b2 headers
 
 script:
-  - ./b2 -j 3 libs/serialization/test toolset=$TOOLSET
+  - ./b2 -j 3 libs/serialization/test toolset=$TOOLSET link=${LINK:-shared}
 
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,11 @@ branches:
     - develop
 #    - master
 
+environment:
+  matrix:
+    - BUILD_TOOLSET: gcc
+    - BUILD_TOOLSET: msvc-14.0
+
 install:
   - cd ..
   - git clone -b %APPVEYOR_REPO_BRANCH%  https://github.com/boostorg/boost.git boost-root
@@ -66,4 +71,4 @@ build: off
 
 test_script:
   - cd libs/serialization/test
-  - b2 toolset=gcc link=static,shared
+  - b2 toolset=%BUILD_TOOLSET% link=static,shared

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ install:
   - git submodule init libs/concept_check
   - git submodule init libs/config
   - git submodule init libs/container
+  - git submodule init libs/container_hash
   - git submodule init libs/core
   - git submodule init libs/detail
   - git submodule init libs/filesystem

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,13 @@ branches:
 environment:
   matrix:
     - BUILD_TOOLSET: gcc
+      BUILD_LINK: static
+    - BUILD_TOOLSET: gcc
+      BUILD_LINK: shared
     - BUILD_TOOLSET: msvc-14.0
+      BUILD_LINK: static
+    - BUILD_TOOLSET: msvc-14.0
+      BUILD_LINK: shared
 
 install:
   - cd ..
@@ -71,4 +77,4 @@ build: off
 
 test_script:
   - cd libs/serialization/test
-  - b2 -j2 toolset=%BUILD_TOOLSET% link=static,shared
+  - b2 -j2 toolset=%BUILD_TOOLSET% link=%BUILD_LINK%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,4 +71,4 @@ build: off
 
 test_script:
   - cd libs/serialization/test
-  - b2 toolset=%BUILD_TOOLSET% link=static,shared
+  - b2 -j2 toolset=%BUILD_TOOLSET% link=static,shared

--- a/include/boost/serialization/singleton.hpp
+++ b/include/boost/serialization/singleton.hpp
@@ -112,14 +112,14 @@ template <class T>
 class singleton : public singleton_module
 {
 private:
+    // use a wrapper so that types T with protected constructors
+    // can be used
+    class singleton_wrapper : public T {};
+
     static T & m_instance;
     // include this to provoke instantiation at pre-execution time
     static void use(T const *) {}
     static T & get_instance() {
-        // use a wrapper so that types T with protected constructors
-        // can be used
-        class singleton_wrapper : public T {};
-
         // Use a heap-allocated instance to work around static variable
         // destruction order issues: this inner singleton_wrapper<>
         // instance may be destructed before the singleton<> instance.

--- a/include/boost/serialization/singleton.hpp
+++ b/include/boost/serialization/singleton.hpp
@@ -37,7 +37,6 @@
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
 #include <boost/noncopyable.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <boost/serialization/force_include.hpp>
 
 #include <boost/archive/detail/auto_link_archive.hpp>
@@ -126,7 +125,7 @@ private:
         // instance may be destructed before the singleton<> instance.
         // Using a 'dumb' static variable lets us precisely choose the
         // time destructor is invoked.
-        static boost::scoped_ptr<singleton_wrapper> t (new singleton_wrapper);
+        static singleton_wrapper* t = new singleton_wrapper;
 
         // refer to instance, causing it to be instantiated (and
         // initialized at startup on working compilers)
@@ -160,6 +159,9 @@ public:
         get_is_destroyed() = false;
     }
     BOOST_DLLEXPORT ~singleton() {
+        if (!get_is_destroyed()) {
+            delete &(get_instance());
+        }
         get_is_destroyed() = true;
     }
 };

--- a/include/boost/serialization/singleton.hpp
+++ b/include/boost/serialization/singleton.hpp
@@ -37,6 +37,7 @@
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
 #include <boost/noncopyable.hpp>
+#include <boost/scoped_ptr.hpp>
 #include <boost/serialization/force_include.hpp>
 
 #include <boost/archive/detail/auto_link_archive.hpp>
@@ -125,7 +126,7 @@ private:
         // instance may be destructed before the singleton<> instance.
         // Using a 'dumb' static variable lets us precisely choose the
         // time destructor is invoked.
-        static singleton_wrapper* t = new singleton_wrapper;
+        static boost::scoped_ptr<singleton_wrapper> t (new singleton_wrapper);
 
         // refer to instance, causing it to be instantiated (and
         // initialized at startup on working compilers)
@@ -159,9 +160,6 @@ public:
         get_is_destroyed() = false;
     }
     BOOST_DLLEXPORT ~singleton() {
-        if (!get_is_destroyed()) {
-            delete &(get_instance());
-        }
         get_is_destroyed() = true;
     }
 };

--- a/include/boost/serialization/singleton.hpp
+++ b/include/boost/serialization/singleton.hpp
@@ -125,7 +125,7 @@ private:
         // instance may be destructed before the singleton<> instance.
         // Using a 'dumb' static variable lets us precisely choose the
         // time destructor is invoked.
-        static singleton_wrapper *t = 0;
+        static singleton_wrapper* t = new singleton_wrapper;
 
         // refer to instance, causing it to be instantiated (and
         // initialized at startup on working compilers)
@@ -137,9 +137,6 @@ private:
         // our usage/implementation of "locking" and introduce uncertainty into
         // the sequence of object initializaition.
         use(& m_instance);
-
-        if (!t)
-            t = new singleton_wrapper;
         return static_cast<T &>(*t);
     }
     static bool & get_is_destroyed(){

--- a/include/boost/serialization/void_cast.hpp
+++ b/include/boost/serialization/void_cast.hpp
@@ -181,13 +181,14 @@ void_caster_primitive<Derived, Base>::void_caster_primitive() :
     void_caster( 
         & type_info_implementation<Derived>::type::get_const_instance(), 
         & type_info_implementation<Base>::type::get_const_instance(),
-        // note:I wanted to displace from 0 here, but at least one compiler
-        // treated 0 by not shifting it at all.
+        /* note about displacement:
+         * displace 0: at least one compiler treated 0 by not shifting it at all
+         * displace by small value (8): caused ICE on certain mingw gcc versions */
         reinterpret_cast<std::ptrdiff_t>(
             static_cast<Derived *>(
-                reinterpret_cast<Base *>(8)
+                reinterpret_cast<Base *>(1 << 20)
             )
-        ) - 8
+        ) - (1 << 20)
     )
 {
     recursive_register();


### PR DESCRIPTION
This avoids issues at process exit when the inner static singleton_wrapper
happens to be cleaned up before the singleton<> instance.