### PR TITLE
Fix a potential thread-safety problem

### DIFF
--- a/include/boost/serialization/singleton.hpp
+++ b/include/boost/serialization/singleton.hpp
@@ -114,7 +114,7 @@ private:
         // instance may be destructed before the singleton<> instance.
         // Using a 'dumb' static variable lets us precisely choose the
         // time destructor is invoked.
-        static singleton_wrapper* t;
+        static singleton_wrapper* t = new singleton_wrapper;
         // refer to instance, causing it to be instantiated (and
         // initialized at startup on working compilers)
         BOOST_ASSERT(! is_destroyed());
@@ -126,7 +126,6 @@ private:
         // our usage/implementation of "locking" and introduce uncertainty into
         // the sequence of object initializaition.
         use(& m_instance);
-        if (!t) t = new singleton_wrapper;
         return static_cast<T &>(*t);
     }
     static bool & get_is_destroyed(){


### PR DESCRIPTION
In reference to https://github.com/boostorg/serialization/pull/79#pullrequestreview-78955218: If different threads don't agree on whether `t` has already been initialized or not, we might run into trouble.